### PR TITLE
♻️ Refactor Layer Structure: Move Enums to Shared, Split DI Setup for Persistence & Infrastructure

### DIFF
--- a/AirlineBookingSystem.API/Program.cs
+++ b/AirlineBookingSystem.API/Program.cs
@@ -8,7 +8,7 @@ Env.Load();
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration
     .AddEnvironmentVariables();
-builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddPersistence(builder.Configuration);
 builder.Services.AddApplication();
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi

--- a/AirlineBookingSystem.API/Program.cs
+++ b/AirlineBookingSystem.API/Program.cs
@@ -2,6 +2,7 @@ using AirlineBookingSystem.Persistence;
 using DotNetEnv;
 using System.IO;
 using AirlineBookingSystem.Application;
+using AirlineBookingSystem.Infrastructure;
 
 // Load environment variables from .env file in current directory
 Env.Load();
@@ -9,6 +10,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Configuration
     .AddEnvironmentVariables();
 builder.Services.AddPersistence(builder.Configuration);
+builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddApplication();
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi

--- a/AirlineBookingSystem.Domain/AirlineBookingSystem.Domain.csproj
+++ b/AirlineBookingSystem.Domain/AirlineBookingSystem.Domain.csproj
@@ -6,4 +6,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\AirlineBookingSystem.Shared\AirlineBookingSystem.Shared.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/AirlineBookingSystem.Domain/Entities/BookingStatus.cs
+++ b/AirlineBookingSystem.Domain/Entities/BookingStatus.cs
@@ -1,4 +1,4 @@
-﻿using AirlineBookingSystem.Domain.Enums;
+﻿using AirlineBookingSystem.Shared.Enums;
 
 namespace AirlineBookingSystem.Domain.Entities
 {

--- a/AirlineBookingSystem.Domain/Entities/Role.cs
+++ b/AirlineBookingSystem.Domain/Entities/Role.cs
@@ -1,10 +1,10 @@
-﻿using AirlineBookingSystem.Domain.Enums;
+﻿using AirlineBookingSystem.Shared.Enums;
 
 namespace AirlineBookingSystem.Domain.Entities
 {
     public class Role
     {
         public int Id { get; set; }
-        public RoleEnum RoleName { get; set; } 
+        public UserRoleEnum RoleName { get; set; } 
     }
 }

--- a/AirlineBookingSystem.Domain/Enums/RoleEnum.cs
+++ b/AirlineBookingSystem.Domain/Enums/RoleEnum.cs
@@ -1,8 +1,0 @@
-namespace AirlineBookingSystem.Domain.Enums;
-
-public enum RoleEnum
-{
-    Admin,
-    Passenger,
-    FlightManager
-}

--- a/AirlineBookingSystem.Infrastructure/AirlineBookingSystem.Infrastructure.csproj
+++ b/AirlineBookingSystem.Infrastructure/AirlineBookingSystem.Infrastructure.csproj
@@ -12,14 +12,4 @@
       <ProjectReference Include="..\AirlineBookingSystem.Shared\AirlineBookingSystem.Shared.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    </ItemGroup>
-
 </Project>

--- a/AirlineBookingSystem.Infrastructure/AirlineBookingSystem.Infrastructure.csproj
+++ b/AirlineBookingSystem.Infrastructure/AirlineBookingSystem.Infrastructure.csproj
@@ -12,4 +12,10 @@
       <ProjectReference Include="..\AirlineBookingSystem.Shared\AirlineBookingSystem.Shared.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Reference Include="Microsoft.Extensions.Configuration.Abstractions">
+        <HintPath>..\..\..\.nuget\packages\microsoft.extensions.configuration.abstractions\9.0.5\lib\net9.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+
 </Project>

--- a/AirlineBookingSystem.Infrastructure/DependencyInjection.cs
+++ b/AirlineBookingSystem.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AirlineBookingSystem.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration config)
+    {
+
+        return services;
+    }
+}

--- a/AirlineBookingSystem.Persistence/Configurations/AddressConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/AddressConfig.cs
@@ -2,13 +2,13 @@ using AirlineBookingSystem.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations;
+namespace AirlineBookingSystem.Persistence.Configurations;
 
-public class AirportConfig : IEntityTypeConfiguration<Airport>
+public class AddressConfig : IEntityTypeConfiguration<Address>
 {
-    public void Configure(EntityTypeBuilder<Airport> builder)
+    public void Configure(EntityTypeBuilder<Address> builder)
     {
-        builder.ToTable("airports");
+        builder.ToTable("addresses");
 
         builder.HasKey(a => a.Id);
         
@@ -16,16 +16,16 @@ public class AirportConfig : IEntityTypeConfiguration<Airport>
             .HasColumnName("id")
             .ValueGeneratedOnAdd();
 
-        builder.Property(a => a.Name)
-            .HasColumnName("name")
+        builder.Property(a => a.Street)
+            .HasColumnName("street")
             .HasColumnType("varchar")
-            .HasMaxLength(100)
+            .HasMaxLength(255)
             .IsRequired();
-
-        builder.Property(a => a.AirportCode)
-            .HasColumnName("airport_code")
+        
+        builder.Property(a => a.ZipCode)
+            .HasColumnName("zip_code")
             .HasColumnType("varchar")
-            .HasMaxLength(10)
+            .HasMaxLength(15)
             .IsRequired();
         
         builder.Property(a => a.CountryId)
@@ -33,8 +33,8 @@ public class AirportConfig : IEntityTypeConfiguration<Airport>
             .HasColumnType("integer");
         
         builder.HasOne(a => a.Country)
-            .WithMany()
-            .HasForeignKey(a => a.CountryId)
+            .WithOne()
+            .HasForeignKey<Address>(a => a.CountryId)
             .OnDelete(DeleteBehavior.Restrict);
         
         builder.Property(a => a.CityId)
@@ -43,11 +43,11 @@ public class AirportConfig : IEntityTypeConfiguration<Airport>
         
         builder.HasOne(a => a.City)
             .WithOne()
-            .HasForeignKey<Airport>(a => a.CityId)
+            .HasForeignKey<Address>(a => a.CityId)
             .OnDelete(DeleteBehavior.Restrict);
         
-        builder.HasIndex(a => a.AirportCode)
-            .HasDatabaseName("ix_airports_airport_code")
+        builder.HasIndex(a => a.ZipCode)
+            .HasDatabaseName("ix_addresses_zip_code")
             .IsUnique();
     }
 }

--- a/AirlineBookingSystem.Persistence/Configurations/AirportConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/AirportConfig.cs
@@ -2,13 +2,13 @@ using AirlineBookingSystem.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations;
+namespace AirlineBookingSystem.Persistence.Configurations;
 
-public class AddressConfig : IEntityTypeConfiguration<Address>
+public class AirportConfig : IEntityTypeConfiguration<Airport>
 {
-    public void Configure(EntityTypeBuilder<Address> builder)
+    public void Configure(EntityTypeBuilder<Airport> builder)
     {
-        builder.ToTable("addresses");
+        builder.ToTable("airports");
 
         builder.HasKey(a => a.Id);
         
@@ -16,16 +16,16 @@ public class AddressConfig : IEntityTypeConfiguration<Address>
             .HasColumnName("id")
             .ValueGeneratedOnAdd();
 
-        builder.Property(a => a.Street)
-            .HasColumnName("street")
+        builder.Property(a => a.Name)
+            .HasColumnName("name")
             .HasColumnType("varchar")
-            .HasMaxLength(255)
+            .HasMaxLength(100)
             .IsRequired();
-        
-        builder.Property(a => a.ZipCode)
-            .HasColumnName("zip_code")
+
+        builder.Property(a => a.AirportCode)
+            .HasColumnName("airport_code")
             .HasColumnType("varchar")
-            .HasMaxLength(15)
+            .HasMaxLength(10)
             .IsRequired();
         
         builder.Property(a => a.CountryId)
@@ -33,8 +33,8 @@ public class AddressConfig : IEntityTypeConfiguration<Address>
             .HasColumnType("integer");
         
         builder.HasOne(a => a.Country)
-            .WithOne()
-            .HasForeignKey<Address>(a => a.CountryId)
+            .WithMany()
+            .HasForeignKey(a => a.CountryId)
             .OnDelete(DeleteBehavior.Restrict);
         
         builder.Property(a => a.CityId)
@@ -43,11 +43,11 @@ public class AddressConfig : IEntityTypeConfiguration<Address>
         
         builder.HasOne(a => a.City)
             .WithOne()
-            .HasForeignKey<Address>(a => a.CityId)
+            .HasForeignKey<Airport>(a => a.CityId)
             .OnDelete(DeleteBehavior.Restrict);
         
-        builder.HasIndex(a => a.ZipCode)
-            .HasDatabaseName("ix_addresses_zip_code")
+        builder.HasIndex(a => a.AirportCode)
+            .HasDatabaseName("ix_airports_airport_code")
             .IsUnique();
     }
 }

--- a/AirlineBookingSystem.Persistence/Configurations/BookingConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/BookingConfig.cs
@@ -2,7 +2,7 @@ using AirlineBookingSystem.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations;
+namespace AirlineBookingSystem.Persistence.Configurations;
 
 public class BookingConfig : IEntityTypeConfiguration<Booking>
 {

--- a/AirlineBookingSystem.Persistence/Configurations/BookingStatusConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/BookingStatusConfig.cs
@@ -2,7 +2,7 @@ using AirlineBookingSystem.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations;
+namespace AirlineBookingSystem.Persistence.Configurations;
 
 public class BookingStatusConfig : IEntityTypeConfiguration<BookingStatus>
 {

--- a/AirlineBookingSystem.Persistence/Configurations/CityConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/CityConfig.cs
@@ -2,7 +2,7 @@ using AirlineBookingSystem.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations;
+namespace AirlineBookingSystem.Persistence.Configurations;
 
 public class CityConfig : IEntityTypeConfiguration<City>
 {

--- a/AirlineBookingSystem.Persistence/Configurations/CountryConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/CountryConfig.cs
@@ -2,7 +2,7 @@ using AirlineBookingSystem.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations;
+namespace AirlineBookingSystem.Persistence.Configurations;
 
 public class CountryConfig : IEntityTypeConfiguration<Country>
 {

--- a/AirlineBookingSystem.Persistence/Configurations/FlightConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/FlightConfig.cs
@@ -2,7 +2,7 @@ using AirlineBookingSystem.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations;
+namespace AirlineBookingSystem.Persistence.Configurations;
 
 public class FlightConfig : IEntityTypeConfiguration<Flight>
 {

--- a/AirlineBookingSystem.Persistence/Configurations/PassengerConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/PassengerConfig.cs
@@ -2,7 +2,7 @@ using AirlineBookingSystem.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations;
+namespace AirlineBookingSystem.Persistence.Configurations;
 
 public class PassengerConfig : IEntityTypeConfiguration<Passenger>
 {

--- a/AirlineBookingSystem.Persistence/Configurations/PersonConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/PersonConfig.cs
@@ -2,7 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations
+namespace AirlineBookingSystem.Persistence.Configurations
 {
     public class PersonConfig : IEntityTypeConfiguration<Person>
     {

--- a/AirlineBookingSystem.Persistence/Configurations/RoleConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/RoleConfig.cs
@@ -2,7 +2,7 @@ using AirlineBookingSystem.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations;
+namespace AirlineBookingSystem.Persistence.Configurations;
 
 public class RoleConfig : IEntityTypeConfiguration<Role>
 {

--- a/AirlineBookingSystem.Persistence/Configurations/UserConfig.cs
+++ b/AirlineBookingSystem.Persistence/Configurations/UserConfig.cs
@@ -2,7 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace AirlineBookingSystem.Infrastructure.Configurations
+namespace AirlineBookingSystem.Persistence.Configurations
 {
     public class UserConfig : IEntityTypeConfiguration<User>
     {

--- a/AirlineBookingSystem.Persistence/DependencyInjection.cs
+++ b/AirlineBookingSystem.Persistence/DependencyInjection.cs
@@ -6,7 +6,7 @@ namespace AirlineBookingSystem.Persistence;
 
 public static class DependencyInjection
 {
-    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddPersistence(this IServiceCollection services, IConfiguration configuration)
     {
         var connectionString = configuration["CONNECTION_STRING"];
 

--- a/AirlineBookingSystem.Shared/Enums/BookingStatusEnum.cs
+++ b/AirlineBookingSystem.Shared/Enums/BookingStatusEnum.cs
@@ -1,4 +1,4 @@
-﻿namespace AirlineBookingSystem.Domain.Enums
+﻿namespace AirlineBookingSystem.Shared.Enums
 {
     public enum BookingStatusEnum
     {

--- a/AirlineBookingSystem.Shared/Enums/UserRoleEnum.cs
+++ b/AirlineBookingSystem.Shared/Enums/UserRoleEnum.cs
@@ -1,0 +1,8 @@
+namespace AirlineBookingSystem.Shared.Enums;
+
+public enum UserRoleEnum
+{
+    Admin,
+    Passenger,
+    FlightManager
+}


### PR DESCRIPTION
This PR introduces architectural improvements to better align with Clean Architecture principles:

---

### 🔧 **Changes Overview:**

1. **♻️ Moved Enums to Shared Layer**

   * `BookingStatusEnum` and `UserRoleEnum` relocated from Domain to Shared for improved reusability.
   * Updated all domain references and namespaces accordingly.

2. **📦 Split Configuration Responsibilities**

   * Moved all `EntityTypeConfiguration` classes from `Infrastructure` to `Persistence`.
   * Renamed namespaces to match the new structure.

3. **🧼 Cleaned Up Unnecessary EF Core References**

   * Removed all EF Core and database provider packages from the `Infrastructure` project.
   * Cleaned up `.csproj` to reduce coupling and improve maintainability.

4. **✨ Introduced DI Registration for Infrastructure**

   * Created `AddInfrastructure` extension method for infrastructure service registration.
   * Adjusted `Program.cs` in API to call `AddInfrastructure` and `AddPersistence` appropriately.

5. **✅ Naming Consistency**

   * Renamed `AddInfrastructure` method in the `Persistence` layer to `AddPersistence` to avoid confusion.

---

### 📁 Affected Projects:

* `AirlineBookingSystem.Shared`
* `AirlineBookingSystem.Domain`
* `AirlineBookingSystem.Persistence`
* `AirlineBookingSystem.Infrastructure`
* `AirlineBookingSystem.API`

---

### 🚫 No Functional Changes

All changes are structural. No runtime or logic modifications were made.

---

### 📌 Motivation:

* Improve project maintainability
* Better align with Clean Architecture standards
* Reduce tight coupling between layers
* Prepare for future scalability