### PR TITLE
feat: Add Docker and Docker Compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.8'
+
+services:
+  postgres-db:
+    image: postgres:15-alpine
+    container_name: postgres_db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=123
+      - POSTGRES_DB=flightDB # .NET database
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker-init-scripts:/docker-entrypoint-initdb.d # Script to create the second DB
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d flightDB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  dotnet-api:
+    build:
+      context: .
+      dockerfile: dotnet-backend/Dockerfile
+    container_name: dotnet_api
+    ports:
+      - "8081:8080"
+    environment:
+      - ConnectionStrings__DefaultConnection=Host=postgres-db;Port=5432;Database=flightDB;Username=postgres;Password=123
+      - ASPNETCORE_URLS=http://+:8080
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+
+  go-booking-service:
+    build:
+      context: ./go-services/booking
+      dockerfile: Dockerfile
+    container_name: go_booking_service
+    ports:
+      - "8080:8080"
+    environment:
+      - DATABASE_URL=postgres://postgres:123@postgres-db:5432/bookingdb?sslmode=disable
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+
+volumes:
+  postgres_data:

--- a/docker-init-scripts/init.sql
+++ b/docker-init-scripts/init.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE bookingdb;

--- a/dotnet-backend/Dockerfile
+++ b/dotnet-backend/Dockerfile
@@ -1,0 +1,32 @@
+# Stage 1: Build the application
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Copy solution and project files
+COPY ["dotnet-backend/AirlineBookingSystem.sln", "dotnet-backend/"]
+COPY ["dotnet-backend/AirlineBookingSystem.API/AirlineBookingSystem.API.csproj", "dotnet-backend/AirlineBookingSystem.API/"]
+COPY ["dotnet-backend/AirlineBookingSystem.Application/AirlineBookingSystem.Application.csproj", "dotnet-backend/AirlineBookingSystem.Application/"]
+COPY ["dotnet-backend/AirlineBookingSystem.Domain/AirlineBookingSystem.Domain.csproj", "dotnet-backend/AirlineBookingSystem.Domain/"]
+COPY ["dotnet-backend/AirlineBookingSystem.Infrastructure/AirlineBookingSystem.Infrastructure.csproj", "dotnet-backend/AirlineBookingSystem.Infrastructure/"]
+COPY ["dotnet-backend/AirlineBookingSystem.Persistence/AirlineBookingSystem.Persistence.csproj", "dotnet-backend/AirlineBookingSystem.Persistence/"]
+COPY ["dotnet-backend/AirlineBookingSystem.Shared/AirlineBookingSystem.Shared.csproj", "dotnet-backend/AirlineBookingSystem.Shared/"]
+
+# Restore dependencies
+RUN dotnet restore "dotnet-backend/AirlineBookingSystem.sln"
+
+# Copy the rest of the source code
+COPY ["dotnet-backend/", "dotnet-backend/"]
+WORKDIR "/src/dotnet-backend"
+
+# Publish the application
+RUN dotnet publish "AirlineBookingSystem.API/AirlineBookingSystem.API.csproj" -c Release -o /app/publish
+
+# Stage 2: Create the final image
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app/publish .
+
+# Expose the port
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "AirlineBookingSystem.API.dll"]

--- a/go-services/booking/Dockerfile
+++ b/go-services/booking/Dockerfile
@@ -1,0 +1,29 @@
+# Stage 1: Build the Go binary
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Copy module files and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the application
+WORKDIR /app/cmd/bookingservice
+RUN CGO_ENABLED=0 GOOS=linux go build -o /main .
+
+# Stage 2: Create the final, minimal image
+FROM alpine:latest
+
+WORKDIR /app
+
+# Copy the binary from the builder stage
+COPY --from=builder /main .
+
+# Expose the port the service runs on
+EXPOSE 8080
+
+# Run the binary
+ENTRYPOINT ["/main"]


### PR DESCRIPTION
### Description:

This pull request introduces a complete Docker and Docker Compose setup to containerize the entire application stack. This will streamline the development process, ensure consistency across environments, and simplify deployment.

#### Changes Made:

*   **Added `dotnet-backend/Dockerfile`**: A multi-stage Dockerfile to build an optimized, production-ready image for the .NET API.
*   **Added `go-services/booking/Dockerfile`**: A multi-stage Dockerfile to build a minimal, efficient image for the Go booking microservice.
*   **Added `docker-compose.yml`**: An orchestration file to define and run all services (`dotnet-api`, `go-booking-service`, `postgres-db`) with a single command. It handles networking, environment variables, and service dependencies.
*   **Added `docker-init-scripts/init.sql`**: A database initialization script to automatically create the required databases when the PostgreSQL container starts.

#### How to Test:

1.  Ensure you have Docker and Docker Compose installed.
2.  From the root of the project, run the following command:
    ```bash
    docker-compose up --build
    ```
3.  This will build the images and start all containers.
    *   The Go booking service will be accessible at `http://localhost:8080`.
    *   The .NET API will be accessible at `http://localhost:8081`.
