### PR TITLE
feat(api): add rate limiting to all endpoints

### DIFF
--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/AirplaneController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/AirplaneController.cs
@@ -8,6 +8,8 @@ using AirlineBookingSystem.Shared.Results.Error;
 using AirlineBookingSystem.Application.Features.Airplanes.Commands.Create;
 using AirlineBookingSystem.Application.Features.Airplanes.Commands.Update;
 using AirlineBookingSystem.Application.Features.Airplanes.Queries.Search;
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -15,6 +17,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [Route("api/airplanes")]
 [ApiController]
+[EnableRateLimiting("fixed")]
 public class AirplaneController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/AirportController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/AirportController.cs
@@ -8,6 +8,8 @@ using AirlineBookingSystem.Application.Features.Airports.Commands.Update;
 using AirlineBookingSystem.Application.Features.Airports.Queries.GetById;
 using AirlineBookingSystem.Application.Features.Airports.Queries.Search;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -15,6 +17,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/airports")]
+[EnableRateLimiting("fixed")]
 public class AirportController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/AuthController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/AuthController.cs
@@ -8,6 +8,8 @@ using AirlineBookingSystem.Application.Interfaces;
 using AirlineBookingSystem.Persistence.DbContext;
 using Microsoft.EntityFrameworkCore;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -15,6 +17,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/auth")]
+[EnableRateLimiting("fixed")]
 public class AuthController : ControllerBase
 {
     private readonly ISender _mediator;

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/BookingStatusesController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/BookingStatusesController.cs
@@ -6,6 +6,8 @@ using AirlineBookingSystem.Application.Features.BookingStatuses.Queries.GetById;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -13,6 +15,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/booking-statuses")]
+[EnableRateLimiting("fixed")]
 public class BookingStatusesController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/CitiesController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/CitiesController.cs
@@ -5,6 +5,8 @@ using AirlineBookingSystem.Shared.Results;
 using AirlineBookingSystem.Shared.Results.Error;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -12,6 +14,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [Route("api/cities")]
 [ApiController]
+[EnableRateLimiting("fixed")]
 public class CitiesController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/ClassTypesController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/ClassTypesController.cs
@@ -6,6 +6,8 @@ using AirlineBookingSystem.Application.Features.ClassTypes.Queries.GetById;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -13,6 +15,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/class-types")]
+[EnableRateLimiting("fixed")]
 public class ClassTypesController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/CountriesController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/CountriesController.cs
@@ -6,6 +6,8 @@ using AirlineBookingSystem.Shared.Results.Error;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -13,6 +15,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [Route("api/countries")]
 [ApiController]
+[EnableRateLimiting("fixed")]
 public class CountriesController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/FlightClassesController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/FlightClassesController.cs
@@ -9,6 +9,8 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using ExistingFlightClassDto = AirlineBookingSystem.Shared.DTOs.flightClasses.FlightClassDto;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -16,6 +18,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/flight-classes")]
+[EnableRateLimiting("fixed")]
 public class FlightClassesController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/FlightController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/FlightController.cs
@@ -13,6 +13,8 @@ using AirlineBookingSystem.Application.Features.Flights.Commands.Update;
 using AirlineBookingSystem.Application.Features.Flights.Queries.GetById;
 using AirlineBookingSystem.Application.Features.Flights.Queries.Search;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -21,6 +23,7 @@ namespace AirlineBookingSystem.API.Controllers;
 [Route("api/[controller]")]
 [ApiController]
 [Authorize]
+[EnableRateLimiting("fixed")]
 public class FlightController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/FlightStatusesController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/FlightStatusesController.cs
@@ -6,6 +6,8 @@ using AirlineBookingSystem.Application.Features.FlightStatuses.Queries.GetById;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -13,6 +15,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/flight-statuses")]
+[EnableRateLimiting("fixed")]
 public class FlightStatusesController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/GatesController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/GatesController.cs
@@ -8,6 +8,8 @@ using AirlineBookingSystem.Shared.Results.Error;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -15,6 +17,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/gates")]
+[EnableRateLimiting("fixed")]
 public class GatesController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/GendersController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/GendersController.cs
@@ -6,6 +6,8 @@ using AirlineBookingSystem.Application.Features.Genders.Queries.GetById;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -13,6 +15,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/genders")]
+[EnableRateLimiting("fixed")]
 public class GendersController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/PaymentController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/PaymentController.cs
@@ -6,6 +6,8 @@ using System.Text;
 using Microsoft.Extensions.Configuration;
 using System;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers
 {
     /// <summary>
@@ -13,6 +15,7 @@ namespace AirlineBookingSystem.API.Controllers
     /// </summary>
     [ApiController]
     [Route("api/[controller]")]
+    [EnableRateLimiting("fixed")]
     public class PaymentController : ControllerBase
     {
         private readonly HttpClient _httpClient;

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/PermissionsController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/PermissionsController.cs
@@ -6,6 +6,8 @@ using AirlineBookingSystem.Shared.Results.Error;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -13,6 +15,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/permissions")]
+[EnableRateLimiting("fixed")]
 public class PermissionsController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/RolesController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/RolesController.cs
@@ -10,6 +10,8 @@ using AirlineBookingSystem.Shared.Results.Error;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -17,6 +19,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/roles")]
+[EnableRateLimiting("fixed")]
 public class RolesController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/SeatController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/SeatController.cs
@@ -8,6 +8,8 @@ using AirlineBookingSystem.Shared.Results.Error;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -15,6 +17,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [Route("api/seats")]
 [ApiController]
+[EnableRateLimiting("fixed")]
 public class SeatController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/TerminalsController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/TerminalsController.cs
@@ -9,6 +9,8 @@ using AirlineBookingSystem.Application.Features.Terminals.Commands.Update;
 using AirlineBookingSystem.Application.Features.Terminals.Queries.GetById;
 using AirlineBookingSystem.Application.Features.Terminals.Queries.Search;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -16,6 +18,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/terminals")]
+[EnableRateLimiting("fixed")]
 public class TerminalsController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/dotnet-backend/AirlineBookingSystem.API/Controllers/UsersController.cs
+++ b/dotnet-backend/AirlineBookingSystem.API/Controllers/UsersController.cs
@@ -9,6 +9,8 @@ using AirlineBookingSystem.Shared.Results;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
+using Microsoft.AspNetCore.RateLimiting;
+
 namespace AirlineBookingSystem.API.Controllers;
 
 /// <summary>
@@ -16,6 +18,7 @@ namespace AirlineBookingSystem.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/users")]
+[EnableRateLimiting("fixed")]
 public class UsersController(ISender sender) : ControllerBase
 {
     /// <summary>


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Description

This pull request introduces rate limiting to the API to protect against DDoS attacks. It adds a fixed window rate limiter to all API endpoints, configured to allow 10 requests per 10 seconds. This is a security measure to ensure the stability and availability of the service.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
