### PR TITLE
feat: Add Go payment service to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,5 +60,20 @@ services:
       postgres-db:
         condition: service_healthy
 
+  go-payment-service:
+    build:
+      context: ./go-services/payment
+      dockerfile: Dockerfile
+    container_name: go_payment_service
+    ports:
+      - "8082:8080" # Exposing on 8082 to avoid conflict
+    environment:
+      - STRIPE_SECRET_KEY=
+      - STRIPE_WEBHOOK_SECRET=
+      - DOTNET_BACKEND_URL=http://dotnet-api:8080
+    depends_on:
+      dotnet-api:
+        condition: service_healthy
+
 volumes:
   postgres_data:

--- a/go-services/payment/Dockerfile
+++ b/go-services/payment/Dockerfile
@@ -1,0 +1,28 @@
+# Stage 1: Build the Go binary
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Copy module files and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the application
+RUN CGO_ENABLED=0 GOOS=linux go build -o /main .
+
+# Stage 2: Create the final, minimal image
+FROM alpine:latest
+
+WORKDIR /app
+
+# Copy the binary from the builder stage
+COPY --from=builder /main .
+
+# Expose the port the service runs on
+EXPOSE 8080
+
+# Run the binary
+ENTRYPOINT ["/main"]


### PR DESCRIPTION
### PR Title

**feat: Add Go payment service to Docker Compose**

---

### Description

This PR introduces the **Go-based Payment Service** into the project’s Dockerized environment.

* Added a dedicated **Dockerfile** for the Payment Service, modeled after the existing Booking Service Dockerfile.
* Integrated the Payment Service into `docker-compose.yml`.
* Configured essential **environment variables**, including placeholders for Stripe API secrets (to be set in `.env`).
* Exposed the Payment Service on **port 8082**, ensuring no conflicts with other services.

---

### Changes

* `go-services/payment-service/Dockerfile`
* `docker-compose.yml`

---

### Environment Variables

The following variables must be set in your `.env` file:

```env
STRIPE_SECRET_KEY=your_stripe_secret_here
STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_here
```

---

### How to Test

1. Rebuild and start the stack:

   ```bash
   docker-compose up --build
   ```
2. Verify that the **Payment Service** container is running on port `8082`.
3. Make a test request:

   ```bash
   curl http://localhost:8082/health
   ```

   Expected response: `{ "status": "ok" }` (or the implemented health response).

---

### Notes

* This service is currently scaffolded with placeholder Stripe integration.
* Further work will include wiring payment endpoints to booking workflows and handling real payment events.
